### PR TITLE
fix the rule arguments contains colon(:)

### DIFF
--- a/lib/FieldValidator.js
+++ b/lib/FieldValidator.js
@@ -77,7 +77,8 @@ class FieldValidator extends BaseValidator {
                     const argsplit = rsplit[rs].split(':');
 
                     if (typeof argsplit[1] !== 'undefined') {
-                        const args = argsplit[1].split(',');
+                        const argstr = argsplit.slice(1).join(':');
+                        const args = argstr.split(',');
 
                         this.rule = {
                             rule: argsplit[0],
@@ -136,7 +137,8 @@ class FieldValidator extends BaseValidator {
                 const fargsSplit = fSplit[f].split(':');
 
                 if (typeof fargsSplit[1] !== 'undefined') {
-                    const args = fargsSplit[1].split(',');
+                    const argstr = fargsSplit.slice(1).join(':');
+                    const args = argstr.split(',');
 
                     typeFilters.push({ filter: fargsSplit[0], args: args });
                 } else {


### PR DESCRIPTION
for example:
`yield this.validateBody({
  date: "dateFormat:YYYY-MM-DD HH:mm:ss"
})`